### PR TITLE
Add a Deploy to Render button

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ npm run build
 
 2. Upload the contents of the `build` folder to your hosting. This is what you can find live at [https://pretzelai.github.io](https://pretzelai.github.io)
 
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+
 ## Optional configuration
 
 - Bug report box: Update `/src/lib/config.ts` with your PostHog config to let users report bugs directly on the website

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+version: "1"
+services:
+- type: web
+  name: pretzelai
+  runtime: static
+  buildCommand: npm run build
+  staticPublishPath: build


### PR DESCRIPTION
This PR adds a "Deploy to Render" button to make it easy to deploy PretzelAI GUI to a public host.