### PR TITLE
Fix "null" string value loading for CSV parser

### DIFF
--- a/src/components/Upload.tsx
+++ b/src/components/Upload.tsx
@@ -121,7 +121,7 @@ export default function Upload({
           }
         }
         csvString +=
-          cell !== null && cell !== "null" && cell !== undefined && !cellIsNan
+          cell !== null && cell !== undefined && !cellIsNan
             ? cell
             : ""
         csvString += cellIndex < row.length - 1 ? delimiter : ""


### PR DESCRIPTION
Previously, the string literal "null" was interpreted as being empty however, this is being changed so that cells containing "null" stay as the string literal