### PR TITLE
#48 issue:  Update Pivot.tsx

### DIFF
--- a/src/components/Pivot.tsx
+++ b/src/components/Pivot.tsx
@@ -227,7 +227,7 @@ export default function PivotTable({
                           <SelectItem value="stddev">Std Dev</SelectItem>
                           <SelectItem value="variance">Variance</SelectItem>
                           <SelectItem value="first">First Value</SelectItem>
-                          <SelectItem value="var_samp">Last Value</SelectItem>
+                          <SelectItem value="last">Last Value</SelectItem> 
                           <SelectItem value="arbitrary">
                             Arbitrary Value
                           </SelectItem>


### PR DESCRIPTION
Hello
This PR resolves the issue #48 i.e. when selecting a Pivot Table with "Last Value" as Values aggregation, instead of the last value, the sample variance is returned.
Thanks for your time. 